### PR TITLE
fix: duplicate field Result in vis-state.go

### DIFF
--- a/lib/datafmts/vis/vis-state.go
+++ b/lib/datafmts/vis/vis-state.go
@@ -18,7 +18,6 @@ type QueryRunnerState struct {
   PeersDialed    int
   PeersToQuery   int
   PeersRemaining int
-  Result         int // number of records
   RateLimit      RateLimit
   Result         QueryResult
   StartTime      string


### PR DESCRIPTION
Removing duplicate field `Result` from `vis-state.go`. I have decided to remove the `int` one because that is what the example in https://github.com/libp2p/dht-tracer1/blob/master/lib/datafmts/vis/vis-state suggested.

This should unblock introduction of CI in this repository: https://github.com/libp2p/dht-tracer1/pull/3 